### PR TITLE
Improve autocomplete compatibility

### DIFF
--- a/scripts/Autocomplete.mjs
+++ b/scripts/Autocomplete.mjs
@@ -4,14 +4,18 @@ export default class Autocomplete {
     handleRenderSidebarTab(app, html, data) {
         /* Set up markup for our UI to be injected */
         const $whisperMenuContainer = $('<div id="command-menu"></div>');
-        const $ghostTextarea = $('<textarea class="chatghosttextarea" autocomplete="off" readonly disabled></textarea>');
         let $whisperMenu = $('<nav id="context-menu" class="expand-up"><ol class="context-items"></ol></nav>');
+
+        if (!game.modules.get("autocomplete-whisper")?.active) {
+            // Create preview field when Autocomplete Whisper is not active.
+            const $ghostTextarea = $('<textarea class="chatghosttextarea" autocomplete="off" readonly disabled></textarea>');
+            $("#chat-message").after($ghostTextarea);
+        }
 
         let regex = new RegExp("\/[A-z]*");
 
         /* Add our UI to the DOM */
         $("#chat-message").before($whisperMenuContainer);
-        $("#chat-message").after($ghostTextarea);
 
         /* Unbind original FVTT chat textarea keydown handler and implemnt our own to catch up/down keys first */
         $("#chat-message").off("keydown");

--- a/scripts/Autocomplete.mjs
+++ b/scripts/Autocomplete.mjs
@@ -17,9 +17,24 @@ export default class Autocomplete {
         /* Add our UI to the DOM */
         $("#chat-message").before($whisperMenuContainer);
 
-        /* Unbind original FVTT chat textarea keydown handler and implemnt our own to catch up/down keys first */
-        $("#chat-message").off("keydown");
-        $("#chat-message").on("keydown.menufocus", jumpToMenuHandler);
+        /**
+         * Binds an event handler so that it is executed before other handlers on the
+         *  same element. Note that handlers defined in the DOM can still run before it.
+         * @param {jQuery} element The parent JQuery element to bind the listeners on.
+         * @param {String} eventName The name and namespace of the event.
+         * @param {String?} selector An optional selector that the event will be active for.
+         * @param {Function} eventHandler The handler of the event.
+         * @returns {jQuery} The original JQuery element for easier chaining.
+         */
+        function onFirst(element, eventName, selector, eventHandler) {
+            element.on(eventName, selector, eventHandler);
+
+            let handlers = jQuery._data(element[0]).events[eventName.split('.')[0]];
+            handlers.unshift(handlers.pop());
+            return element;
+        }
+
+        onFirst($("#chat-message"), "keydown.menufocus", jumpToMenuHandler);
         /* Listen for chat input. Do stuff.*/
         $("#chat-message").on("input.whisperer", handleChatInput);
         /* Listen for "]" to close an array of targets (names) */
@@ -208,19 +223,6 @@ export default class Autocomplete {
                     return false;
                 }
             }
-            if (game.modules.get("autocomplete-whisper") != undefined) {
-              if ($("#whisper-menu").find("li").length) {
-                if (e.which === 38) { // `up`
-                  $("#whisper-menu li:last-child").focus();
-                  return false;
-                } else if (e.which === 40) { // `down`
-                  $("#whisper-menu li:first-child").focus();
-                  return false;
-                }
-              }
-            }
-            // if player menu is not visible/DNE, execute FVTT's original keydown handler
-            ui.chat._onChatKeyDown(e);
         }
     
         function menuNavigationHandler(e) {

--- a/styles/chatcommands.css
+++ b/styles/chatcommands.css
@@ -4,15 +4,14 @@
   
   #chat-form .chatghosttextarea {
     position: absolute;
-    top: 0;
-    left: 0px;
+    top: 1px;
+    left: 1px;
     z-index: 1;
     opacity: 0.5;
     box-shadow: none;
     outline: none;
     pointer-events: none;
     background: transparent;
-    display: none;
   }
   
   .chatghosttextarea:not(.show) {


### PR DESCRIPTION
This module is currently using very uncooperative ways of performing its autocomplete. These two commits clean things up at least a little.
- The ghost text area is now only created if Autocomplete Whisper is not installed. In the future, it would be helpful if Autocomplete Whisper would also check if the new element already exists. At that point, the code here can be changed to do the same.
- The ghost text area is now visible when appropriate.
- The `keydown.menufocus` handler now uses a trick to register itself as the first event handler. This allows it to not care about what other modules (including FoundryVTT itself) are doing afterwards.